### PR TITLE
Add unit test for PayableEntity

### DIFF
--- a/backend/src/payable/application/usecases/__tests__/payable.create.usecase.unit.spec.ts
+++ b/backend/src/payable/application/usecases/__tests__/payable.create.usecase.unit.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { CreatePayableUseCase } from '../payable.create.usecase'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { AssignorRepository } from '@/assignor/domain/assignor.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+import { AssignorEntity } from '@/assignor/domain/assignor.entity'
+import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
+import { AssignorDataBuilder } from '@/assignor/domain/__tests__/assignor.data-builder'
+
+describe('CreatePayableUseCase unit tests', () => {
+  let sut: CreatePayableUseCase
+  let payableRepository: jest.Mocked<PayableRepository>
+  let assignorRepository: jest.Mocked<AssignorRepository>
+
+  beforeEach(async () => {
+    const mockPayableRepository = {
+      create: jest.fn(),
+    }
+    const mockAssignorRepository = {
+      findById: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreatePayableUseCase,
+        { provide: PayableRepository, useValue: mockPayableRepository },
+        { provide: AssignorRepository, useValue: mockAssignorRepository },
+      ],
+    }).compile()
+
+    sut = module.get<CreatePayableUseCase>(CreatePayableUseCase)
+    payableRepository = module.get(PayableRepository)
+    assignorRepository = module.get(AssignorRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should create a new payable when assignor exists', async () => {
+    const assignor = new AssignorEntity(AssignorDataBuilder())
+    const data = PayableDataBuilder({ assignorId: assignor.props.id })
+    const payable = new PayableEntity(data)
+
+    assignorRepository.findById.mockResolvedValue(assignor)
+    payableRepository.create.mockResolvedValue(payable)
+
+    const result = await sut.execute({
+      value: data.value,
+      emissionDate: data.emissionDate,
+      assignorId: data.assignorId,
+    })
+
+    expect(assignorRepository.findById).toHaveBeenCalledWith(data.assignorId)
+    expect(payableRepository.create).toHaveBeenCalledWith(expect.any(PayableEntity))
+    expect(result).toEqual(payable)
+  })
+
+  it('should throw NotFoundException if assignor does not exist', async () => {
+    const data = PayableDataBuilder()
+
+    assignorRepository.findById.mockResolvedValue(null)
+
+    await expect(
+      sut.execute({
+        value: data.value,
+        emissionDate: data.emissionDate,
+        assignorId: data.assignorId,
+      }),
+    ).rejects.toThrow(NotFoundException)
+
+    expect(assignorRepository.findById).toHaveBeenCalledWith(data.assignorId)
+    expect(payableRepository.create).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/payable/application/usecases/__tests__/payable.delete.usecase.unit.spec.ts
+++ b/backend/src/payable/application/usecases/__tests__/payable.delete.usecase.unit.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { DeletePayableUseCase } from '../payable.delete.usecase'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
+
+describe('DeletePayableUseCase unit tests', () => {
+  let sut: DeletePayableUseCase
+  let repository: jest.Mocked<PayableRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+      delete: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeletePayableUseCase,
+        { provide: PayableRepository, useValue: mockRepository },
+      ],
+    }).compile()
+
+    sut = module.get<DeletePayableUseCase>(DeletePayableUseCase)
+    repository = module.get(PayableRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should delete payable when it exists', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+
+    repository.findById.mockResolvedValue(entity)
+    repository.delete.mockResolvedValue()
+
+    await expect(sut.execute(entity.props.id as string)).resolves.toBeUndefined()
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.delete).toHaveBeenCalledWith(entity.props.id)
+  })
+
+  it('should throw NotFoundException if payable does not exist', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(sut.execute(entity.props.id as string)).rejects.toThrow(
+      NotFoundException,
+    )
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.delete).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/payable/application/usecases/__tests__/payable.find-by-id.usecase.unit.spec.ts
+++ b/backend/src/payable/application/usecases/__tests__/payable.find-by-id.usecase.unit.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { FindPayableByIdUseCase } from '../payable.find-by-id.usecase'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
+
+describe('FindPayableByIdUseCase unit tests', () => {
+  let sut: FindPayableByIdUseCase
+  let repository: jest.Mocked<PayableRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindPayableByIdUseCase,
+        { provide: PayableRepository, useValue: mockRepository },
+      ],
+    }).compile()
+
+    sut = module.get<FindPayableByIdUseCase>(FindPayableByIdUseCase)
+    repository = module.get(PayableRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should return payable when found', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+
+    repository.findById.mockResolvedValue(entity)
+
+    const result = await sut.execute(entity.props.id as string)
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(result).toEqual(entity)
+  })
+
+  it('should throw NotFoundException if payable does not exist', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(sut.execute(entity.props.id as string)).rejects.toThrow(
+      NotFoundException,
+    )
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+  })
+})

--- a/backend/src/payable/application/usecases/__tests__/payable.update.usecase.unit.spec.ts
+++ b/backend/src/payable/application/usecases/__tests__/payable.update.usecase.unit.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { UpdatePayableUseCase } from '../payable.update.usecase'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
+import { UpdatePayableDto } from '../../dtos/payable.update.dto'
+
+describe('UpdatePayableUseCase unit tests', () => {
+  let sut: UpdatePayableUseCase
+  let repository: jest.Mocked<PayableRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+      update: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdatePayableUseCase,
+        { provide: PayableRepository, useValue: mockRepository },
+      ],
+    }).compile()
+
+    sut = module.get<UpdatePayableUseCase>(UpdatePayableUseCase)
+    repository = module.get(PayableRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should update payable when it exists', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+    const updateData: UpdatePayableDto = { value: 500 }
+    const updatedEntity = new PayableEntity({ ...entity.props, ...updateData })
+
+    repository.findById.mockResolvedValue(entity)
+    repository.update.mockResolvedValue(updatedEntity)
+
+    const result = await sut.execute({ id: entity.props.id as string, data: updateData })
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.update).toHaveBeenCalledWith(expect.any(PayableEntity))
+    expect(result).toEqual(updatedEntity)
+  })
+
+  it('should throw NotFoundException if payable does not exist', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(
+      sut.execute({ id: entity.props.id as string, data: {} }),
+    ).rejects.toThrow(NotFoundException)
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.update).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/payable/domain/__tests__/payable.data-builder.ts
+++ b/backend/src/payable/domain/__tests__/payable.data-builder.ts
@@ -1,0 +1,14 @@
+import { faker } from '@faker-js/faker/.'
+import { PayableProps } from '../payable.entity'
+
+export function PayableDataBuilder(overrides?: Partial<PayableProps>): PayableProps {
+  return {
+    id: faker.string.uuid(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    value: faker.number.int({ min: 100, max: 10000 }),
+    emissionDate: faker.date.recent(),
+    assignorId: faker.string.uuid(),
+    ...overrides,
+  }
+}

--- a/backend/src/payable/domain/__tests__/payable.entity.unit.spec.ts
+++ b/backend/src/payable/domain/__tests__/payable.entity.unit.spec.ts
@@ -1,0 +1,20 @@
+import { PayableEntity, PayableProps } from '../payable.entity'
+import { PayableDataBuilder } from './payable.data-builder'
+
+describe('PayableEntity unit tests', () => {
+  let props: PayableProps
+  let sut: PayableEntity
+
+  beforeEach(() => {
+    props = PayableDataBuilder()
+    sut = new PayableEntity(props)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should have the correct properties', () => {
+    expect(sut.props).toStrictEqual(props)
+  })
+})


### PR DESCRIPTION
## Summary
- add PayableEntity unit tests to verify entity initialization

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_6850321b426c832f850c80deafb38534