### PR TITLE
Add User module

### DIFF
--- a/backend/prisma/schema/migrations/20250616160000_add_user/migration.sql
+++ b/backend/prisma/schema/migrations/20250616160000_add_user/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "login" TEXT NOT NULL,
+    "password" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_login_key" ON "users"("login");

--- a/backend/prisma/schema/models/user.prisma
+++ b/backend/prisma/schema/models/user.prisma
@@ -1,0 +1,11 @@
+model User {
+  id        String   @id @default(uuid())
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  login    String   @unique
+  password String
+
+  @@map("users")
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config'
 import { HealthModule } from './health/health.module'
 import { PayabledModule } from './payable/payable.module'
 import { AssignorModule } from './assignor/assignor.module'
+import { UserModule } from './user/user.module'
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { AssignorModule } from './assignor/assignor.module'
     HealthModule,
     PayabledModule,
     AssignorModule,
+    UserModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/user/application/dtos/user.create.dto.ts
+++ b/backend/src/user/application/dtos/user.create.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+import { IsNotEmpty, IsString, Length } from 'class-validator'
+
+export class CreateUserDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  login: string
+
+  @ApiProperty({ example: 'P@ssw0rd' })
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @Length(6, 140)
+  password: string
+}

--- a/backend/src/user/application/dtos/user.update.dto.ts
+++ b/backend/src/user/application/dtos/user.update.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger'
+import { CreateUserDto } from './user.create.dto'
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/backend/src/user/application/usecases/__tests__/user.create.usecase.unit.spec.ts
+++ b/backend/src/user/application/usecases/__tests__/user.create.usecase.unit.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ConflictException } from '@nestjs/common'
+import { UserRepository } from '@/user/domain/user.repository'
+import { CreateUserDto } from '../../dtos/user.create.dto'
+import { UserEntity } from '@/user/domain/user.entity'
+import { CreateUserUseCase } from '../user.create.usecase'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+
+describe('CreateUserUseCase unit tests', () => {
+  let sut: CreateUserUseCase
+  let repository: jest.Mocked<UserRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findByLogin: jest.fn(),
+      create: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateUserUseCase,
+        {
+          provide: UserRepository,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    sut = module.get<CreateUserUseCase>(CreateUserUseCase)
+    repository = module.get(UserRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should create a new user when login does not exist', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findByLogin.mockResolvedValue(null)
+    repository.create.mockResolvedValue(entity)
+
+    const result = await sut.execute(entity.props as CreateUserDto)
+
+    expect(repository.findByLogin).toHaveBeenCalledWith(entity.props.login)
+    expect(repository.create).toHaveBeenCalledWith(expect.any(UserEntity))
+    expect(result).toEqual(entity)
+  })
+
+  it('should throw ConflictException if user login already exists', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findByLogin.mockResolvedValue(entity)
+
+    await expect(sut.execute(entity.props as CreateUserDto)).rejects.toThrow(
+      ConflictException,
+    )
+
+    expect(repository.findByLogin).toHaveBeenCalledWith(entity.props.login)
+    expect(repository.create).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/user/application/usecases/__tests__/user.delete.usecase.unit.spec.ts
+++ b/backend/src/user/application/usecases/__tests__/user.delete.usecase.unit.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { DeleteUserUseCase } from '../user.delete.usecase'
+import { UserRepository } from '@/user/domain/user.repository'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+
+describe('DeleteUserUseCase unit tests', () => {
+  let sut: DeleteUserUseCase
+  let repository: jest.Mocked<UserRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+      delete: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteUserUseCase,
+        {
+          provide: UserRepository,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    sut = module.get<DeleteUserUseCase>(DeleteUserUseCase)
+    repository = module.get(UserRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should delete user when it exists', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findById.mockResolvedValue(entity)
+    repository.delete.mockResolvedValue()
+
+    await expect(sut.execute(entity.props.id as string)).resolves.toBeUndefined()
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.delete).toHaveBeenCalledWith(entity.props.id)
+  })
+
+  it('should throw NotFoundException if user does not exist', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(sut.execute(entity.props.id as string)).rejects.toThrow(
+      NotFoundException,
+    )
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.delete).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/user/application/usecases/__tests__/user.find-by-id.usecase.unit.spec.ts
+++ b/backend/src/user/application/usecases/__tests__/user.find-by-id.usecase.unit.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { FindUserByIdUseCase } from '../user.find-by-id.usecase'
+import { UserRepository } from '@/user/domain/user.repository'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+
+describe('FindUserByIdUseCase unit tests', () => {
+  let sut: FindUserByIdUseCase
+  let repository: jest.Mocked<UserRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindUserByIdUseCase,
+        {
+          provide: UserRepository,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    sut = module.get<FindUserByIdUseCase>(FindUserByIdUseCase)
+    repository = module.get(UserRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should return user when found', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findById.mockResolvedValue(entity)
+
+    const result = await sut.execute(entity.props.id as string)
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(result).toEqual(entity)
+  })
+
+  it('should throw NotFoundException if user does not exist', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(sut.execute(entity.props.id as string)).rejects.toThrow(
+      NotFoundException,
+    )
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+  })
+})

--- a/backend/src/user/application/usecases/__tests__/user.update.usecase.unit.spec.ts
+++ b/backend/src/user/application/usecases/__tests__/user.update.usecase.unit.spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { UpdateUserUseCase } from '../user.update.usecase'
+import { UserRepository } from '@/user/domain/user.repository'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+import { UpdateUserDto } from '../../dtos/user.update.dto'
+
+describe('UpdateUserUseCase unit tests', () => {
+  let sut: UpdateUserUseCase
+  let repository: jest.Mocked<UserRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+      update: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateUserUseCase,
+        {
+          provide: UserRepository,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    sut = module.get<UpdateUserUseCase>(UpdateUserUseCase)
+    repository = module.get(UserRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should update user when it exists', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const updateData: UpdateUserDto = { login: 'new@login.com' }
+    const updatedEntity = new UserEntity({ ...entity.props, ...updateData })
+
+    repository.findById.mockResolvedValue(entity)
+    repository.update.mockResolvedValue(updatedEntity)
+
+    const result = await sut.execute({
+      id: entity.props.id as string,
+      data: updateData,
+    })
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.update).toHaveBeenCalledWith(expect.any(UserEntity))
+    expect(result).toEqual(updatedEntity)
+  })
+
+  it('should throw NotFoundException if user does not exist', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    repository.findById.mockResolvedValue(null)
+
+    await expect(
+      sut.execute({ id: entity.props.id as string, data: {} }),
+    ).rejects.toThrow(NotFoundException)
+
+    expect(repository.findById).toHaveBeenCalledWith(entity.props.id)
+    expect(repository.update).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/user/application/usecases/user.create.usecase.ts
+++ b/backend/src/user/application/usecases/user.create.usecase.ts
@@ -1,0 +1,19 @@
+import { ConflictException, Injectable } from '@nestjs/common'
+import { UserRepository } from '@/user/domain/user.repository'
+import { UserEntity } from '@/user/domain/user.entity'
+import { CreateUserDto } from '../dtos/user.create.dto'
+
+@Injectable()
+export class CreateUserUseCase {
+  constructor(protected readonly userRepository: UserRepository) {}
+
+  async execute(data: CreateUserDto): Promise<UserEntity> {
+    const user = await this.userRepository.findByLogin(data.login)
+
+    if (user) {
+      throw new ConflictException(`User login already exists`)
+    }
+
+    return await this.userRepository.create(new UserEntity({ ...data }))
+  }
+}

--- a/backend/src/user/application/usecases/user.delete.usecase.ts
+++ b/backend/src/user/application/usecases/user.delete.usecase.ts
@@ -1,0 +1,17 @@
+import { UserRepository } from '@/user/domain/user.repository'
+import { Injectable, NotFoundException } from '@nestjs/common'
+
+@Injectable()
+export class DeleteUserUseCase {
+  constructor(protected readonly userRepository: UserRepository) {}
+
+  async execute(id: string): Promise<void> {
+    const user = await this.userRepository.findById(id)
+
+    if (!user) {
+      throw new NotFoundException()
+    }
+
+    return this.userRepository.delete(id)
+  }
+}

--- a/backend/src/user/application/usecases/user.find-by-id.usecase.ts
+++ b/backend/src/user/application/usecases/user.find-by-id.usecase.ts
@@ -1,0 +1,18 @@
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserRepository } from '@/user/domain/user.repository'
+import { Injectable, NotFoundException } from '@nestjs/common'
+
+@Injectable()
+export class FindUserByIdUseCase {
+  constructor(protected readonly userRepository: UserRepository) {}
+
+  async execute(id: string): Promise<UserEntity> {
+    const user = await this.userRepository.findById(id)
+
+    if (!user) {
+      throw new NotFoundException()
+    }
+
+    return user
+  }
+}

--- a/backend/src/user/application/usecases/user.update.usecase.ts
+++ b/backend/src/user/application/usecases/user.update.usecase.ts
@@ -1,0 +1,23 @@
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserRepository } from '@/user/domain/user.repository'
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { UpdateUserDto } from '../dtos/user.update.dto'
+
+@Injectable()
+export class UpdateUserUseCase {
+  constructor(protected readonly userRepository: UserRepository) {}
+
+  async execute(input: { id: string; data: UpdateUserDto }): Promise<UserEntity> {
+    const user = await this.userRepository.findById(input.id)
+
+    if (!user) {
+      throw new NotFoundException()
+    }
+
+    const updatedUser = await this.userRepository.update(
+      new UserEntity({ ...user.props, ...input.data })
+    )
+
+    return updatedUser
+  }
+}

--- a/backend/src/user/domain/__tests__/user.data-builder.ts
+++ b/backend/src/user/domain/__tests__/user.data-builder.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker/.'
+import { UserProps } from '../user.entity'
+
+export function UserDataBuilder(overrides?: Partial<UserProps>): UserProps {
+  return {
+    id: faker.string.uuid(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    login: faker.internet.email(),
+    password: faker.internet.password(),
+    ...overrides,
+  }
+}

--- a/backend/src/user/domain/__tests__/user.entity.unit.spec.ts
+++ b/backend/src/user/domain/__tests__/user.entity.unit.spec.ts
@@ -1,0 +1,20 @@
+import { UserEntity, UserProps } from '../user.entity'
+import { UserDataBuilder } from './user.data-builder'
+
+describe('UserEntity unit tests', () => {
+  let props: UserProps
+  let sut: UserEntity
+
+  beforeEach(() => {
+    props = UserDataBuilder()
+    sut = new UserEntity(props)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should have the correct properties', () => {
+    expect(sut.props).toStrictEqual(props)
+  })
+})

--- a/backend/src/user/domain/user.entity.ts
+++ b/backend/src/user/domain/user.entity.ts
@@ -1,0 +1,21 @@
+import { v4 as uuidv4 } from 'uuid'
+
+export type UserProps = {
+  id?: string
+  createdAt?: Date
+  updatedAt?: Date
+  login: string
+  password: string
+}
+
+export class UserEntity {
+  props: UserProps
+
+  constructor(props: UserProps) {
+    props.id = props.id || uuidv4()
+    props.createdAt = props.createdAt || new Date()
+    props.updatedAt = props.updatedAt || new Date()
+
+    this.props = props
+  }
+}

--- a/backend/src/user/domain/user.repository.ts
+++ b/backend/src/user/domain/user.repository.ts
@@ -1,0 +1,9 @@
+import { UserEntity } from './user.entity'
+
+export abstract class UserRepository {
+  abstract create(user: UserEntity): Promise<UserEntity>
+  abstract findById(id: string): Promise<UserEntity | null>
+  abstract update(user: UserEntity): Promise<UserEntity>
+  abstract delete(id: string): Promise<void>
+  abstract findByLogin(login: string): Promise<UserEntity | null>
+}

--- a/backend/src/user/infrastructure/__tests__/user-prisma.repository.int.spec.ts
+++ b/backend/src/user/infrastructure/__tests__/user-prisma.repository.int.spec.ts
@@ -1,0 +1,91 @@
+import { Test } from '@nestjs/testing'
+import { UserPrismaRepository } from '../user-prisma.repository'
+import { PrismaService } from '@/shared/infrastructure/database/prisma.service'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+
+describe('UserPrismaRepository integration tests', () => {
+  let sut: UserPrismaRepository
+  let prisma: PrismaService
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [PrismaService, UserPrismaRepository],
+    }).compile()
+
+    sut = module.get<UserPrismaRepository>(UserPrismaRepository)
+    prisma = module.get<PrismaService>(PrismaService)
+
+    await prisma.user.deleteMany({})
+  })
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({})
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it(`should create a new user`, async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const created = await sut.create(entity)
+
+    expect(created).toBeInstanceOf(UserEntity)
+    expect(created.props).toBeDefined()
+  })
+
+  it(`should finds a user by id`, async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const created = await sut.create(entity)
+
+    const found = await sut.findById(created.props.id)
+
+    expect(found).toBeInstanceOf(UserEntity)
+    expect(created.props).toBeDefined()
+  })
+
+  it(`should return null when id does not exist`, async () => {
+    const notFound = await sut.findById('non-existing-id')
+    expect(notFound).toBeNull()
+  })
+
+  it(`should update an user`, async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const created = await sut.create(entity)
+
+    const newData = new UserEntity(
+      UserDataBuilder({ id: created.props.id, login: 'updated@test.com' }),
+    )
+    const updated = await sut.update(newData)
+
+    expect(updated).toBeInstanceOf(UserEntity)
+    expect(created.props).toBeDefined()
+    expect(updated.props.login).toBe('updated@test.com')
+  })
+
+  it(`should delete an user`, async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const created = await sut.create(entity)
+
+    await sut.delete(created.props.id)
+
+    const found = await sut.findById(created.props.id)
+    expect(found).toBeNull()
+  })
+
+  it(`should find an user by login`, async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    const created = await sut.create(entity)
+
+    const found = await sut.findByLogin(created.props.login)
+
+    expect(found).toBeInstanceOf(UserEntity)
+    expect(found.props.login).toBe(created.props.login)
+  })
+
+  it(`should return null when login does not exist`, async () => {
+    const notFound = await sut.findByLogin('non-existing-login')
+    expect(notFound).toBeNull()
+  })
+})

--- a/backend/src/user/infrastructure/__tests__/user-prisma.repository.unit.spec.ts
+++ b/backend/src/user/infrastructure/__tests__/user-prisma.repository.unit.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { UserPrismaRepository } from '../user-prisma.repository'
+import { PrismaService } from '@/shared/infrastructure/database/prisma.service'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+
+describe('UserPrismaRepository unit tests', () => {
+  let sut: UserPrismaRepository
+
+  const mockPrismaService = {
+    user: {
+      create: jest.fn().mockRejectedValue(new Error()),
+      findUnique: jest.fn().mockRejectedValue(new Error()),
+      update: jest.fn().mockRejectedValue(new Error()),
+      delete: jest.fn().mockRejectedValue(new Error()),
+    },
+  }
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserPrismaRepository,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile()
+
+    sut = module.get<UserPrismaRepository>(UserPrismaRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should call handlePrismaError when create fails', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    await expect(sut.create(entity)).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when findById fails', async () => {
+    await expect(sut.findById('fake-id')).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when update fails', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+    await expect(sut.update(entity)).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when delete fails', async () => {
+    await expect(sut.delete('fake-id')).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when find by login fails', async () => {
+    await expect(sut.findByLogin('fake-login')).rejects.toThrow(Error)
+  })
+})

--- a/backend/src/user/infrastructure/__tests__/user.controller.unit.spec.ts
+++ b/backend/src/user/infrastructure/__tests__/user.controller.unit.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { plainToInstance } from 'class-transformer'
+import { UserController } from '../user.controller'
+import { CreateUserUseCase } from '@/user/application/usecases/user.create.usecase'
+import { FindUserByIdUseCase } from '@/user/application/usecases/user.find-by-id.usecase'
+import { UpdateUserUseCase } from '@/user/application/usecases/user.update.usecase'
+import { DeleteUserUseCase } from '@/user/application/usecases/user.delete.usecase'
+import { UserEntity } from '@/user/domain/user.entity'
+import { UserDataBuilder } from '@/user/domain/__tests__/user.data-builder'
+import { CreateUserDto } from '@/user/application/dtos/user.create.dto'
+import { UserResponseDto } from '../user.response.dto'
+import { UpdateUserDto } from '@/user/application/dtos/user.update.dto'
+
+describe('UserController unit tests', () => {
+  let sut: UserController
+  let createUserUseCase: jest.Mocked<CreateUserUseCase>
+  let findUserByIdUseCase: jest.Mocked<FindUserByIdUseCase>
+  let updateUserUseCase: jest.Mocked<UpdateUserUseCase>
+  let deleteUserUseCase: jest.Mocked<DeleteUserUseCase>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [
+        {
+          provide: CreateUserUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: FindUserByIdUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: UpdateUserUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: DeleteUserUseCase,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile()
+
+    sut = module.get<UserController>(UserController)
+    createUserUseCase = module.get(CreateUserUseCase)
+    findUserByIdUseCase = module.get(FindUserByIdUseCase)
+    updateUserUseCase = module.get(UpdateUserUseCase)
+    deleteUserUseCase = module.get(DeleteUserUseCase)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should create a user successfully', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    createUserUseCase.execute.mockResolvedValue(entity)
+
+    const createDto = plainToInstance(CreateUserDto, entity, { excludeExtraneousValues: true })
+
+    const result = await sut.create(createDto)
+
+    expect(createUserUseCase.execute).toHaveBeenCalledWith(createDto)
+    expect(createUserUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result).toBeInstanceOf(UserResponseDto)
+  })
+
+  it('should find a user by id successfully', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    findUserByIdUseCase.execute = jest.fn().mockResolvedValue(entity)
+
+    const result = await sut.findById(entity.props.id)
+
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledWith(entity.props.id)
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result.id).toStrictEqual(entity.props.id)
+    expect(result).toBeInstanceOf(UserResponseDto)
+  })
+
+  it('should update a user successfully', async () => {
+    const entity = new UserEntity(UserDataBuilder())
+
+    updateUserUseCase.execute.mockResolvedValue(entity)
+
+    const updateDto = plainToInstance(UpdateUserDto, entity, { excludeExtraneousValues: true })
+
+    const result = await sut.update(entity.props.id, updateDto)
+
+    expect(updateUserUseCase.execute).toHaveBeenCalledWith({
+      id: entity.props.id,
+      data: updateDto,
+    })
+    expect(updateUserUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result).toBeInstanceOf(UserResponseDto)
+  })
+
+  it('should delete a user successfully', async () => {
+    const result = await sut.remove('fake-uuid')
+
+    expect(deleteUserUseCase.execute).toHaveBeenCalledWith('fake-uuid')
+    expect(deleteUserUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(undefined)
+  })
+})

--- a/backend/src/user/infrastructure/user-prisma.repository.ts
+++ b/backend/src/user/infrastructure/user-prisma.repository.ts
@@ -1,0 +1,71 @@
+import { PrismaService } from '@/shared/infrastructure/database/prisma.service'
+import { UserEntity } from '../domain/user.entity'
+import { UserRepository } from '../domain/user.repository'
+import { handlePrismaError } from '@/shared/infrastructure/database/handle-prisma-error'
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class UserPrismaRepository implements UserRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(user: UserEntity): Promise<UserEntity> {
+    try {
+      const created = await this.prisma.user.create({
+        data: {
+          ...user.props,
+        },
+      })
+
+      return new UserEntity(created)
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
+
+  async findById(id: string): Promise<UserEntity | null> {
+    try {
+      const found = await this.prisma.user.findUnique({ where: { id } })
+
+      if (!found) return null
+
+      return new UserEntity(found)
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
+
+  async update(user: UserEntity): Promise<UserEntity> {
+    try {
+      const updated = await this.prisma.user.update({
+        where: { id: user.props.id },
+        data: {
+          ...user.props,
+        },
+      })
+
+      return new UserEntity(updated)
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.prisma.user.delete({ where: { id } })
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
+
+  async findByLogin(login: string): Promise<UserEntity | null> {
+    try {
+      const found = await this.prisma.user.findUnique({ where: { login } })
+
+      if (!found) return null
+
+      return new UserEntity(found)
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
+}

--- a/backend/src/user/infrastructure/user.controller.ts
+++ b/backend/src/user/infrastructure/user.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common'
+import { CreateUserUseCase } from '../application/usecases/user.create.usecase'
+import { FindUserByIdUseCase } from '../application/usecases/user.find-by-id.usecase'
+import { UpdateUserUseCase } from '../application/usecases/user.update.usecase'
+import { DeleteUserUseCase } from '../application/usecases/user.delete.usecase'
+import { CreateUserDto } from '../application/dtos/user.create.dto'
+import {
+  CreateUserDoc,
+  DeleteUserDoc,
+  FindUserByIdDoc,
+  UpdateUserDoc,
+} from './user.doc'
+import { UserPresenter } from './user.presenter'
+import { UpdateUserDto } from '../application/dtos/user.update.dto'
+
+@Controller('user')
+export class UserController {
+  constructor(
+    private readonly createUserUseCase: CreateUserUseCase,
+    private readonly findUserByIdUseCase: FindUserByIdUseCase,
+    private readonly updateUserUseCase: UpdateUserUseCase,
+    private readonly deleteUserUseCase: DeleteUserUseCase,
+  ) {}
+
+  @CreateUserDoc()
+  @Post()
+  async create(@Body() createUserDto: CreateUserDto) {
+    const createdUser = await this.createUserUseCase.execute(createUserDto)
+
+    return UserPresenter.toHttp(createdUser)
+  }
+
+  @FindUserByIdDoc()
+  @Get(':id')
+  async findById(@Param('id') id: string) {
+    const user = await this.findUserByIdUseCase.execute(id)
+    return UserPresenter.toHttp(user)
+  }
+
+  @UpdateUserDoc()
+  @Patch(':id')
+  async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    const updatedUser = await this.updateUserUseCase.execute({ id, data: updateUserDto })
+    return UserPresenter.toHttp(updatedUser)
+  }
+
+  @DeleteUserDoc()
+  @Delete(':id')
+  async remove(@Param('id') id: string) {
+    return await this.deleteUserUseCase.execute(id)
+  }
+}

--- a/backend/src/user/infrastructure/user.doc.ts
+++ b/backend/src/user/infrastructure/user.doc.ts
@@ -1,0 +1,51 @@
+import { applyDecorators } from '@nestjs/common'
+import { ApiParam, ApiResponse } from '@nestjs/swagger'
+import { UserResponseDto } from './user.response.dto'
+
+export function CreateUserDoc() {
+  return applyDecorators(
+    ApiResponse({
+      status: 201,
+      description: 'Item created',
+      type: UserResponseDto,
+    }),
+    ApiResponse({
+      status: 422,
+      description: 'Invalid request body',
+      schema: {
+        example: {
+          statusCode: 422,
+          message: [],
+          error: 'Unprocessable Entity',
+        },
+      },
+    }),
+  )
+}
+
+export function FindUserByIdDoc() {
+  return applyDecorators(
+    ApiParam({ name: 'id', format: 'uuid' }),
+    ApiResponse({
+      status: 200,
+      description: 'Item found',
+      type: UserResponseDto,
+    }),
+    ApiResponse({ status: 404, description: 'Item not found' }),
+  )
+}
+
+export function UpdateUserDoc() {
+  return applyDecorators(
+    ApiParam({ name: 'id', format: 'uuid' }),
+    ApiResponse({ status: 200, description: 'Item updated', type: UserResponseDto })
+  )
+}
+
+export function DeleteUserDoc() {
+  return applyDecorators(
+    ApiParam({ name: 'id', format: 'uuid' }),
+    ApiResponse({ status: 200, description: 'Item deleted' }),
+    ApiResponse({ status: 404, description: 'Item not found' }),
+  )
+}

--- a/backend/src/user/infrastructure/user.presenter.ts
+++ b/backend/src/user/infrastructure/user.presenter.ts
@@ -1,0 +1,11 @@
+import { plainToInstance } from 'class-transformer'
+import { UserResponseDto } from './user.response.dto'
+import { UserEntity } from '../domain/user.entity'
+
+export class UserPresenter {
+  static toHttp(userEntity: UserEntity): UserResponseDto {
+    return plainToInstance(UserResponseDto, userEntity.props, {
+      excludeExtraneousValues: true,
+    })
+  }
+}

--- a/backend/src/user/infrastructure/user.response.dto.ts
+++ b/backend/src/user/infrastructure/user.response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+
+export class UserResponseDto {
+  @Expose()
+  @ApiProperty({ format: 'uuid' })
+  id: string
+
+  @Expose()
+  @ApiProperty()
+  createdAt: Date
+
+  @Expose()
+  @ApiProperty()
+  updatedAt: Date
+
+  @Expose()
+  @ApiProperty()
+  login: string
+
+  @Expose()
+  @ApiProperty()
+  password: string
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common'
+import { PrismaService } from '@/shared/infrastructure/database/prisma.service'
+import { UserRepository } from './domain/user.repository'
+import { UserPrismaRepository } from './infrastructure/user-prisma.repository'
+import { CreateUserUseCase } from './application/usecases/user.create.usecase'
+import { DeleteUserUseCase } from './application/usecases/user.delete.usecase'
+import { FindUserByIdUseCase } from './application/usecases/user.find-by-id.usecase'
+import { UpdateUserUseCase } from './application/usecases/user.update.usecase'
+import { UserController } from './infrastructure/user.controller'
+
+@Module({
+  imports: [],
+  controllers: [UserController],
+  providers: [
+    PrismaService,
+    {
+      provide: UserRepository,
+      useClass: UserPrismaRepository,
+    },
+    CreateUserUseCase,
+    DeleteUserUseCase,
+    FindUserByIdUseCase,
+    UpdateUserUseCase,
+  ],
+  exports: [UserRepository],
+})
+export class UserModule {}


### PR DESCRIPTION
## Summary
- create User entity, repository, use cases and controller
- implement presenter, dto and docs for User
- wire UserModule into AppModule
- add Prisma model and migration for users
- include comprehensive unit and integration tests

## Testing
- `npm run test:unit`
- `npm run test:int`


------
https://chatgpt.com/codex/tasks/task_b_6850a14d823c832fb8a2d7a3b7fb9f7e