### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY backend/package*.json ./backend/
+WORKDIR /app/backend
+RUN npm ci
+COPY backend .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine
+WORKDIR /app/backend
+COPY --from=build /app/backend/dist ./dist
+COPY --from=build /app/backend/node_modules ./node_modules
+COPY --from=build /app/backend/prisma ./prisma
+COPY backend/package.json ./package.json
+RUN mkdir -p /app/database
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Aprove-me API
+
+Este repositório contém uma API desenvolvida em [NestJS](https://nestjs.com/) com Prisma.
+
+## Como preparar o ambiente
+
+1. Instale o Node.js na versão 20 ou superior.
+2. Copie o arquivo `backend/.env.example` para `backend/.env` e preencha as variáveis necessárias.
+
+## Como instalar as dependências
+
+Dentro do diretório `backend` execute:
+
+```bash
+npm ci
+```
+
+## Como rodar o projeto
+
+### Modo de desenvolvimento
+
+Ainda em `backend` execute:
+
+```bash
+npm run start:dev
+```
+
+### Utilizando Docker
+
+Foi criado um `Dockerfile` e um `docker-compose.yaml` para facilitar a execução da API.
+
+Para construir a imagem:
+
+```bash
+docker build -t aprove-me-api .
+```
+
+Para iniciar a aplicação com o Docker Compose:
+
+```bash
+docker compose up
+```
+
+A aplicação ficará disponível em `http://localhost:3000/integrations`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Este repositório contém uma API desenvolvida em [NestJS](https://nestjs.com/) 
 
 1. Instale o Node.js na versão 20 ou superior.
 2. Copie o arquivo `backend/.env.example` para `backend/.env` e preencha as variáveis necessárias.
+3. Crie a pasta `database` na raiz do projeto para armazenar o arquivo `dev.db` quando usar Docker.
 
 ## Como instalar as dependências
 
@@ -38,7 +39,8 @@ docker build -t aprove-me-api .
 Para iniciar a aplicação com o Docker Compose:
 
 ```bash
-docker compose up
+docker compose up -d
+docker compose exec api npx prisma migrate deploy
 ```
 
 A aplicação ficará disponível em `http://localhost:3000/integrations`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       NODE_ENV: production
       APP_PORT: 3000
-      DATABASE_URL: file:../database/dev.db
+      DATABASE_URL: file:/app/database/dev.db
       JWT_SECRET: changeme
     volumes:
       - ./database:/app/database

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - '3000:3000'
+    environment:
+      NODE_ENV: production
+      APP_PORT: 3000
+      DATABASE_URL: file:../database/dev.db
+      JWT_SECRET: changeme
+    volumes:
+      - ./database:/app/database
+


### PR DESCRIPTION
## Summary
- create Dockerfile for building and running the API
- add docker-compose.yaml with basic service definition
- document setup and usage in README

## Testing
- `npm run test:unit`
- `npm run test:int`

------
https://chatgpt.com/codex/tasks/task_b_6850c03c6fcc832fbab225d1c19796b9