### PR TITLE
Add list assignors API route

### DIFF
--- a/backend/src/assignor/application/usecases/__tests__/assignor.find-all.usecase.unit.spec.ts
+++ b/backend/src/assignor/application/usecases/__tests__/assignor.find-all.usecase.unit.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { FindAllAssignorsUseCase } from '../assignor.find-all.usecase'
+import { AssignorRepository } from '@/assignor/domain/assignor.repository'
+import { AssignorEntity } from '@/assignor/domain/assignor.entity'
+import { AssignorDataBuilder } from '@/assignor/domain/__tests__/assignor.data-builder'
+
+describe('FindAllAssignorsUseCase unit tests', () => {
+  let sut: FindAllAssignorsUseCase
+  let repository: jest.Mocked<AssignorRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAll: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAllAssignorsUseCase,
+        { provide: AssignorRepository, useValue: mockRepository },
+      ],
+    }).compile()
+
+    sut = module.get<FindAllAssignorsUseCase>(FindAllAssignorsUseCase)
+    repository = module.get(AssignorRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should return list of assignors', async () => {
+    const entity = new AssignorEntity(AssignorDataBuilder())
+    repository.findAll.mockResolvedValue([entity])
+
+    const result = await sut.execute()
+
+    expect(repository.findAll).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([entity])
+  })
+})

--- a/backend/src/assignor/application/usecases/assignor.find-all.usecase.ts
+++ b/backend/src/assignor/application/usecases/assignor.find-all.usecase.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common'
+import { AssignorRepository } from '@/assignor/domain/assignor.repository'
+import { AssignorEntity } from '@/assignor/domain/assignor.entity'
+
+@Injectable()
+export class FindAllAssignorsUseCase {
+  constructor(protected readonly assignorRepository: AssignorRepository) {}
+
+  async execute(): Promise<AssignorEntity[]> {
+    return this.assignorRepository.findAll()
+  }
+}

--- a/backend/src/assignor/assignor.module.ts
+++ b/backend/src/assignor/assignor.module.ts
@@ -6,6 +6,7 @@ import { CreateAssignorUseCase } from './application/usecases/assignor.create.us
 import { DeleteAssignorUseCase } from './application/usecases/assignor.delete.usecase'
 import { FindAssignorByIdUseCase } from './application/usecases/assignor.find-by-id.usecase'
 import { UpdateAssignorUseCase } from './application/usecases/assignor.update.usecase'
+import { FindAllAssignorsUseCase } from './application/usecases/assignor.find-all.usecase'
 import { AssignorController } from './infrastructure/assignor.controller'
 
 @Module({
@@ -19,6 +20,7 @@ import { AssignorController } from './infrastructure/assignor.controller'
     },
     CreateAssignorUseCase,
     DeleteAssignorUseCase,
+    FindAllAssignorsUseCase,
     FindAssignorByIdUseCase,
     UpdateAssignorUseCase,
   ],

--- a/backend/src/assignor/domain/assignor.repository.ts
+++ b/backend/src/assignor/domain/assignor.repository.ts
@@ -6,4 +6,5 @@ export abstract class AssignorRepository {
   abstract update(assignor: AssignorEntity): Promise<AssignorEntity>
   abstract delete(id: string): Promise<void>
   abstract findByDocument(document: string): Promise<AssignorEntity | null>
+  abstract findAll(): Promise<AssignorEntity[]>
 }

--- a/backend/src/assignor/infrastructure/__tests__/assignor-prisma.repository.int.spec.ts
+++ b/backend/src/assignor/infrastructure/__tests__/assignor-prisma.repository.int.spec.ts
@@ -89,6 +89,17 @@ describe('AssignorPrismaRepository integration tests', () => {
     expect(found.props.document).toBe(created.props.document)
   })
 
+  it(`should list assignors`, async () => {
+    await prisma.assignor.deleteMany({})
+    const entity = new AssignorEntity(AssignorDataBuilder())
+    await sut.create(entity)
+
+    const result = await sut.findAll()
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result[0]).toBeInstanceOf(AssignorEntity)
+  })
+
   it(`should return null when document does not exist`, async () => {
     const notFound = await sut.findByDocument('non-existing-document')
     expect(notFound).toBeNull()

--- a/backend/src/assignor/infrastructure/__tests__/assignor-prisma.repository.unit.spec.ts
+++ b/backend/src/assignor/infrastructure/__tests__/assignor-prisma.repository.unit.spec.ts
@@ -11,6 +11,7 @@ describe('AssignorPrismaRepository unit tests', () => {
     assignor: {
       create: jest.fn().mockRejectedValue(new Error()),
       findUnique: jest.fn().mockRejectedValue(new Error()),
+      findMany: jest.fn().mockRejectedValue(new Error()),
       update: jest.fn().mockRejectedValue(new Error()),
       delete: jest.fn().mockRejectedValue(new Error()),
     },
@@ -55,5 +56,9 @@ describe('AssignorPrismaRepository unit tests', () => {
 
   it('should call handlePrismaError when find by document fails', async () => {
     await expect(sut.findByDocument('fake-document')).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when findAll fails', async () => {
+    await expect(sut.findAll()).rejects.toThrow(Error)
   })
 })

--- a/backend/src/assignor/infrastructure/__tests__/assignor.controller.unit.spec.ts
+++ b/backend/src/assignor/infrastructure/__tests__/assignor.controller.unit.spec.ts
@@ -5,6 +5,7 @@ import { CreateAssignorUseCase } from '@/assignor/application/usecases/assignor.
 import { FindAssignorByIdUseCase } from '@/assignor/application/usecases/assignor.find-by-id.usecase'
 import { UpdateAssignorUseCase } from '@/assignor/application/usecases/assignor.update.usecase'
 import { DeleteAssignorUseCase } from '@/assignor/application/usecases/assignor.delete.usecase'
+import { FindAllAssignorsUseCase } from '@/assignor/application/usecases/assignor.find-all.usecase'
 import { AssignorEntity } from '@/assignor/domain/assignor.entity'
 import { AssignorDataBuilder } from '@/assignor/domain/__tests__/assignor.data-builder'
 import { CreateAssignorDto } from '@/assignor/application/dtos/assignor.create.dto'
@@ -15,6 +16,7 @@ describe('AssignorController unit tests', () => {
   let sut: AssignorController
   let createAssignorUseCase: jest.Mocked<CreateAssignorUseCase>
   let findAssignorByIdUseCase: jest.Mocked<FindAssignorByIdUseCase>
+  let findAllAssignorsUseCase: jest.Mocked<FindAllAssignorsUseCase>
   let updateAssignorUseCase: jest.Mocked<UpdateAssignorUseCase>
   let deleteAssignorUseCase: jest.Mocked<DeleteAssignorUseCase>
 
@@ -30,6 +32,12 @@ describe('AssignorController unit tests', () => {
         },
         {
           provide: FindAssignorByIdUseCase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+        {
+          provide: FindAllAssignorsUseCase,
           useValue: {
             execute: jest.fn(),
           },
@@ -52,6 +60,7 @@ describe('AssignorController unit tests', () => {
     sut = module.get<AssignorController>(AssignorController)
     createAssignorUseCase = module.get(CreateAssignorUseCase)
     findAssignorByIdUseCase = module.get(FindAssignorByIdUseCase)
+    findAllAssignorsUseCase = module.get(FindAllAssignorsUseCase)
     updateAssignorUseCase = module.get(UpdateAssignorUseCase)
     deleteAssignorUseCase = module.get(DeleteAssignorUseCase)
   })
@@ -74,6 +83,16 @@ describe('AssignorController unit tests', () => {
     expect(createAssignorUseCase.execute).toHaveBeenCalledWith(createCarDto)
     expect(createAssignorUseCase.execute).toHaveBeenCalledTimes(1)
     expect(result).toBeInstanceOf(AssignorResponseDto)
+  })
+
+  it('should list assignors successfully', async () => {
+    const entity = new AssignorEntity(AssignorDataBuilder())
+    findAllAssignorsUseCase.execute.mockResolvedValue([entity])
+
+    const result = await sut.findAll()
+
+    expect(findAllAssignorsUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result[0]).toBeInstanceOf(AssignorResponseDto)
   })
 
   it('should find a assignor by id successfully', async () => {

--- a/backend/src/assignor/infrastructure/assignor-prisma.repository.ts
+++ b/backend/src/assignor/infrastructure/assignor-prisma.repository.ts
@@ -72,4 +72,13 @@ export class AssignorPrismaRepository implements AssignorRepository {
       handlePrismaError(error)
     }
   }
+
+  async findAll(): Promise<AssignorEntity[]> {
+    try {
+      const found = await this.prisma.assignor.findMany()
+      return found.map((item) => new AssignorEntity(item))
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
 }

--- a/backend/src/assignor/infrastructure/assignor.controller.ts
+++ b/backend/src/assignor/infrastructure/assignor.controller.ts
@@ -11,10 +11,12 @@ import { CreateAssignorUseCase } from '../application/usecases/assignor.create.u
 import { FindAssignorByIdUseCase } from '../application/usecases/assignor.find-by-id.usecase'
 import { UpdateAssignorUseCase } from '../application/usecases/assignor.update.usecase'
 import { DeleteAssignorUseCase } from '../application/usecases/assignor.delete.usecase'
+import { FindAllAssignorsUseCase } from '../application/usecases/assignor.find-all.usecase'
 import { CreateAssignorDto } from '../application/dtos/assignor.create.dto'
 import {
   CreateAssignorDoc,
   DeleteAssignorDoc,
+  FindAllAssignorsDoc,
   FindAssignorByIdDoc,
   UpdateAssignorDoc,
 } from './assignor.doc'
@@ -26,6 +28,7 @@ export class AssignorController {
   constructor(
     private readonly createAssignorUseCase: CreateAssignorUseCase,
     private readonly findAssignorByIdUseCase: FindAssignorByIdUseCase,
+    private readonly findAllAssignorsUseCase: FindAllAssignorsUseCase,
     private readonly updateAssignorUseCase: UpdateAssignorUseCase,
     private readonly deleteAssignorUseCase: DeleteAssignorUseCase,
   ) {}
@@ -37,6 +40,13 @@ export class AssignorController {
       await this.createAssignorUseCase.execute(createAssignorDto)
 
     return AssignorPresenter.toHttp(createdAssignor)
+  }
+
+  @FindAllAssignorsDoc()
+  @Get()
+  async findAll() {
+    const assignors = await this.findAllAssignorsUseCase.execute()
+    return assignors.map((a) => AssignorPresenter.toHttp(a))
   }
 
   @FindAssignorByIdDoc()

--- a/backend/src/assignor/infrastructure/assignor.doc.ts
+++ b/backend/src/assignor/infrastructure/assignor.doc.ts
@@ -76,3 +76,15 @@ export function DeleteAssignorDoc() {
     }),
   )
 }
+
+export function FindAllAssignorsDoc() {
+  return applyDecorators(
+    AuthorizedDoc(),
+    ApiResponse({
+      status: 200,
+      description: 'List of items',
+      type: AssignorResponseDto,
+      isArray: true,
+    }),
+  )
+}


### PR DESCRIPTION
## Summary
- add FindAllAssignorsUseCase
- expose findAll repository method
- add controller endpoint `GET /assignor`
- document new route in Swagger docs
- update tests for repository and controller

## Testing
- `npm run test:unit`
- `npm run test:int`
- `npm run test:e2e` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_685221457afc832f9f79bfc7e513e772