### PR TITLE
Implement payables listing

### DIFF
--- a/frontend/src/components/pages/payable/payable.list.tsx
+++ b/frontend/src/components/pages/payable/payable.list.tsx
@@ -10,8 +10,13 @@ import {
 } from '@/components/ui/table'
 import { Page } from '@/components/layout/page'
 import { Button } from '@/components/ui/button'
+import { useFetchPayables } from '@/hooks/queries/useFetchPayables'
+import { useFetchAssignors } from '@/hooks/queries/useFetchAssignors'
+import { format } from 'date-fns'
 
 export function PayableList() {
+   const { data: payables, isLoading: loadingPayables } = useFetchPayables()
+   const { data: assignors, isLoading: loadingAssignors } = useFetchAssignors()
    const createNewRegister = (
       <Button className="px-4" asChild>
          <Link to={`/app/payables/create`}>
@@ -20,6 +25,10 @@ export function PayableList() {
          </Link>
       </Button>
    )
+
+   if (loadingPayables || loadingAssignors) {
+      return <div>Carregando...</div>
+   }
 
    return (
       <Page title="Pagáveis" actions={createNewRegister}>
@@ -35,30 +44,41 @@ export function PayableList() {
                   </TableRow>
                </TableHeader>
                <TableBody>
-                  <TableRow className="even:bg-muted/40">
-                     <TableCell>1</TableCell>
-                     <TableCell>01/01/2023</TableCell>
-                     <TableCell>R$ 100,00</TableCell>
-                     <TableCell>Empresa XYZ</TableCell>
-                     <TableCell className="flex justify-center">
-                        <Button
-                           variant="ghost"
-                           size="icon"
-                           className="h-5 w-8"
-                           onClick={() => {}}
-                        >
-                           <Pencil />
-                        </Button>
-                        <Button
-                           variant="ghost"
-                           size="icon"
-                           className="h-5 w-8"
-                           onClick={() => {}}
-                        >
-                           <Trash2 className="text-destructive" />
-                        </Button>
-                     </TableCell>
-                  </TableRow>
+                  {payables?.map((payable) => (
+                     <TableRow key={payable.id} className="even:bg-muted/40">
+                        <TableCell>{payable.id}</TableCell>
+                        <TableCell>
+                           {format(payable.emissionDate, 'dd/MM/yyyy')}
+                        </TableCell>
+                        <TableCell>
+                           {new Intl.NumberFormat('pt-BR', {
+                              style: 'currency',
+                              currency: 'BRL',
+                           }).format(payable.value / 100)}
+                        </TableCell>
+                        <TableCell>
+                           {assignors?.find((a) => a.id === payable.assignorId)?.name}
+                        </TableCell>
+                        <TableCell className="flex justify-center">
+                           <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-8"
+                              onClick={() => {}}
+                           >
+                              <Pencil />
+                           </Button>
+                           <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-8"
+                              onClick={() => {}}
+                           >
+                              <Trash2 className="text-destructive" />
+                           </Button>
+                        </TableCell>
+                     </TableRow>
+                  ))}
                </TableBody>
             </Table>
          </div>

--- a/frontend/src/hooks/queries/useFetchPayables.ts
+++ b/frontend/src/hooks/queries/useFetchPayables.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/services/api.service'
+
+export const useFetchPayables = () => {
+  return useQuery({
+    queryKey: ['payables'],
+    queryFn: async () => {
+      const response = await api.get('payable')
+      return response.data.map((item: any) => {
+        const [year, month, day] = item.emissionDate.split('T')[0].split('-')
+        return {
+          ...item,
+          emissionDate: new Date(
+            Number(year),
+            Number(month) - 1,
+            Number(day)
+          ),
+        }
+      })
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add hook for fetching payables
- query payables and assignors on list page
- display payables data in table

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_b_6853436cea38832fa9c07fda243d4c86