### PR TITLE
Implement Payable findAll

### DIFF
--- a/backend/src/payable/application/usecases/__tests__/payable.find-all.usecase.unit.spec.ts
+++ b/backend/src/payable/application/usecases/__tests__/payable.find-all.usecase.unit.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { FindAllPayablesUseCase } from '../payable.find-all.usecase'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
+
+describe('FindAllPayablesUseCase unit tests', () => {
+  let sut: FindAllPayablesUseCase
+  let repository: jest.Mocked<PayableRepository>
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAll: jest.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAllPayablesUseCase,
+        { provide: PayableRepository, useValue: mockRepository },
+      ],
+    }).compile()
+
+    sut = module.get<FindAllPayablesUseCase>(FindAllPayablesUseCase)
+    repository = module.get(PayableRepository)
+  })
+
+  it('should be defined', () => {
+    expect(sut).toBeDefined()
+  })
+
+  it('should return list of payables', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+    repository.findAll.mockResolvedValue([entity])
+
+    const result = await sut.execute()
+
+    expect(repository.findAll).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([entity])
+  })
+})

--- a/backend/src/payable/application/usecases/payable.find-all.usecase.ts
+++ b/backend/src/payable/application/usecases/payable.find-all.usecase.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common'
+import { PayableRepository } from '@/payable/domain/payable.repository'
+import { PayableEntity } from '@/payable/domain/payable.entity'
+
+@Injectable()
+export class FindAllPayablesUseCase {
+  constructor(protected readonly payableRepository: PayableRepository) {}
+
+  async execute(): Promise<PayableEntity[]> {
+    return this.payableRepository.findAll()
+  }
+}

--- a/backend/src/payable/domain/payable.repository.ts
+++ b/backend/src/payable/domain/payable.repository.ts
@@ -5,4 +5,5 @@ export abstract class PayableRepository {
   abstract findById(id: string): Promise<PayableEntity | null>
   abstract update(payable: PayableEntity): Promise<PayableEntity>
   abstract delete(id: string): Promise<void>
+  abstract findAll(): Promise<PayableEntity[]>
 }

--- a/backend/src/payable/infrastructure/__tests__/payable-prisma.repository.int.spec.ts
+++ b/backend/src/payable/infrastructure/__tests__/payable-prisma.repository.int.spec.ts
@@ -94,4 +94,15 @@ describe('PayablePrismaRepository integration tests', () => {
     const found = await sut.findById(created.props.id)
     expect(found).toBeNull()
   })
+
+  it(`should list payables`, async () => {
+    await prisma.payable.deleteMany({})
+    const entity = new PayableEntity(PayableDataBuilder({ assignorId }))
+    await sut.create(entity)
+
+    const result = await sut.findAll()
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result[0]).toBeInstanceOf(PayableEntity)
+  })
 })

--- a/backend/src/payable/infrastructure/__tests__/payable-prisma.repository.unit.spec.ts
+++ b/backend/src/payable/infrastructure/__tests__/payable-prisma.repository.unit.spec.ts
@@ -11,6 +11,7 @@ describe('PayablePrismaRepository unit tests', () => {
     payable: {
       create: jest.fn().mockRejectedValue(new Error()),
       findUnique: jest.fn().mockRejectedValue(new Error()),
+      findMany: jest.fn().mockRejectedValue(new Error()),
       update: jest.fn().mockRejectedValue(new Error()),
       delete: jest.fn().mockRejectedValue(new Error()),
     },
@@ -51,5 +52,9 @@ describe('PayablePrismaRepository unit tests', () => {
 
   it('should call handlePrismaError when delete fails', async () => {
     await expect(sut.delete('fake-id')).rejects.toThrow(Error)
+  })
+
+  it('should call handlePrismaError when findAll fails', async () => {
+    await expect(sut.findAll()).rejects.toThrow(Error)
   })
 })

--- a/backend/src/payable/infrastructure/__tests__/payable.controller.unit.spec.ts
+++ b/backend/src/payable/infrastructure/__tests__/payable.controller.unit.spec.ts
@@ -5,6 +5,7 @@ import { CreatePayableUseCase } from '@/payable/application/usecases/payable.cre
 import { FindPayableByIdUseCase } from '@/payable/application/usecases/payable.find-by-id.usecase'
 import { UpdatePayableUseCase } from '@/payable/application/usecases/payable.update.usecase'
 import { DeletePayableUseCase } from '@/payable/application/usecases/payable.delete.usecase'
+import { FindAllPayablesUseCase } from '@/payable/application/usecases/payable.find-all.usecase'
 import { PayableEntity } from '@/payable/domain/payable.entity'
 import { PayableDataBuilder } from '@/payable/domain/__tests__/payable.data-builder'
 import { CreatePayableDto } from '@/payable/application/dtos/payable.create.dto'
@@ -15,6 +16,7 @@ describe('PayableController unit tests', () => {
   let sut: PayableController
   let createPayableUseCase: jest.Mocked<CreatePayableUseCase>
   let findPayableByIdUseCase: jest.Mocked<FindPayableByIdUseCase>
+  let findAllPayablesUseCase: jest.Mocked<FindAllPayablesUseCase>
   let updatePayableUseCase: jest.Mocked<UpdatePayableUseCase>
   let deletePayableUseCase: jest.Mocked<DeletePayableUseCase>
 
@@ -30,6 +32,12 @@ describe('PayableController unit tests', () => {
         },
         {
           provide: FindPayableByIdUseCase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+        {
+          provide: FindAllPayablesUseCase,
           useValue: {
             execute: jest.fn(),
           },
@@ -52,6 +60,7 @@ describe('PayableController unit tests', () => {
     sut = module.get<PayableController>(PayableController)
     createPayableUseCase = module.get(CreatePayableUseCase)
     findPayableByIdUseCase = module.get(FindPayableByIdUseCase)
+    findAllPayablesUseCase = module.get(FindAllPayablesUseCase)
     updatePayableUseCase = module.get(UpdatePayableUseCase)
     deletePayableUseCase = module.get(DeletePayableUseCase)
   })
@@ -74,6 +83,16 @@ describe('PayableController unit tests', () => {
     expect(createPayableUseCase.execute).toHaveBeenCalledWith(createPayableDto)
     expect(createPayableUseCase.execute).toHaveBeenCalledTimes(1)
     expect(result).toBeInstanceOf(PayableResponseDto)
+  })
+
+  it('should list payables successfully', async () => {
+    const entity = new PayableEntity(PayableDataBuilder())
+    findAllPayablesUseCase.execute.mockResolvedValue([entity])
+
+    const result = await sut.findAll()
+
+    expect(findAllPayablesUseCase.execute).toHaveBeenCalledTimes(1)
+    expect(result[0]).toBeInstanceOf(PayableResponseDto)
   })
 
   it('should find a payable by id successfully', async () => {

--- a/backend/src/payable/infrastructure/payable-prisma.repository.ts
+++ b/backend/src/payable/infrastructure/payable-prisma.repository.ts
@@ -58,4 +58,13 @@ export class PayablePrismaRepository implements PayableRepository {
       handlePrismaError(error)
     }
   }
+
+  async findAll(): Promise<PayableEntity[]> {
+    try {
+      const found = await this.prisma.payable.findMany()
+      return found.map((item) => new PayableEntity(item))
+    } catch (error) {
+      handlePrismaError(error)
+    }
+  }
 }

--- a/backend/src/payable/infrastructure/payable.controller.ts
+++ b/backend/src/payable/infrastructure/payable.controller.ts
@@ -10,6 +10,7 @@ import {
 import {
   CreatePayableDoc,
   DeletePayableDoc,
+  FindAllPayablesDoc,
   FindPayableByIdDoc,
   UpdatePayableDoc,
 } from './payable.doc'
@@ -20,12 +21,14 @@ import { FindPayableByIdUseCase } from '../application/usecases/payable.find-by-
 import { UpdatePayableDto } from '../application/dtos/payable.update.dto'
 import { UpdatePayableUseCase } from '../application/usecases/payable.update.usecase'
 import { DeletePayableUseCase } from '../application/usecases/payable.delete.usecase'
+import { FindAllPayablesUseCase } from '../application/usecases/payable.find-all.usecase'
 
 @Controller('payable')
 export class PayableController {
   constructor(
     private readonly createPayableUseCase: CreatePayableUseCase,
     private readonly findPayableByIdUseCase: FindPayableByIdUseCase,
+    private readonly findAllPayablesUseCase: FindAllPayablesUseCase,
     private readonly updatePayableUseCase: UpdatePayableUseCase,
     private readonly deletePayableUseCase: DeletePayableUseCase,
   ) {}
@@ -37,6 +40,13 @@ export class PayableController {
       await this.createPayableUseCase.execute(createPayableDto)
 
     return PayablePresenter.toHttp(createdPayable)
+  }
+
+  @FindAllPayablesDoc()
+  @Get()
+  async findAll() {
+    const payables = await this.findAllPayablesUseCase.execute()
+    return payables.map((p) => PayablePresenter.toHttp(p))
   }
 
   @FindPayableByIdDoc()

--- a/backend/src/payable/infrastructure/payable.doc.ts
+++ b/backend/src/payable/infrastructure/payable.doc.ts
@@ -77,3 +77,15 @@ export function DeletePayableDoc() {
     }),
   )
 }
+
+export function FindAllPayablesDoc() {
+  return applyDecorators(
+    AuthorizedDoc(),
+    ApiResponse({
+      status: 200,
+      description: 'List of items',
+      type: PayableResponseDto,
+      isArray: true,
+    }),
+  )
+}

--- a/backend/src/payable/payable.module.ts
+++ b/backend/src/payable/payable.module.ts
@@ -8,6 +8,7 @@ import { AssignorModule } from '@/assignor/assignor.module'
 import { FindPayableByIdUseCase } from './application/usecases/payable.find-by-id.usecase'
 import { UpdatePayableUseCase } from './application/usecases/payable.update.usecase'
 import { DeletePayableUseCase } from './application/usecases/payable.delete.usecase'
+import { FindAllPayablesUseCase } from './application/usecases/payable.find-all.usecase'
 
 @Module({
   imports: [AssignorModule],
@@ -20,6 +21,7 @@ import { DeletePayableUseCase } from './application/usecases/payable.delete.usec
     },
     CreatePayableUseCase,
     FindPayableByIdUseCase,
+    FindAllPayablesUseCase,
     UpdatePayableUseCase,
     DeletePayableUseCase,
   ],


### PR DESCRIPTION
## Summary
- implement findAll in Payable repository interface
- add FindAllPayablesUseCase and corresponding unit test
- implement findAll in PayablePrismaRepository with tests
- expose list route in PayableController with swagger docs and update module

## Testing
- `npm run test:unit`
- `npm run test:int`


------
https://chatgpt.com/codex/tasks/task_b_685345ac711c832f98dc69386840a82c