### PR TITLE
Add assignor screens to frontend

### DIFF
--- a/frontend/src/components/pages/assignor/assignor-form.tsx
+++ b/frontend/src/components/pages/assignor/assignor-form.tsx
@@ -1,0 +1,96 @@
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { LoaderCircle } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import type { FormAssignorValues } from '@/hooks/mutations/useUpsertAssignor'
+
+const formSchema = z.object({
+  name: z.string().min(1, 'Nome obrigatório'),
+  document: z.string().min(1, 'Documento obrigatório'),
+  email: z.string().email('E-mail inválido'),
+  phone: z.string().min(1, 'Telefone obrigatório'),
+})
+
+type Props = {
+  initialData?: FormAssignorValues
+  onSubmit: (data: FormAssignorValues) => void
+  isLoading: boolean
+  onCancel: () => void
+}
+
+export function AssignorForm({ initialData, onSubmit, isLoading, onCancel }: Props) {
+  const form = useForm<FormAssignorValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initialData ?? {
+      name: '',
+      document: '',
+      email: '',
+      phone: '',
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <div className="grid grid-cols-12 gap-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem className="col-span-12 sm:col-span-6">
+                <FormLabel>Nome</FormLabel>
+                <Input {...field} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="document"
+            render={({ field }) => (
+              <FormItem className="col-span-12 sm:col-span-6">
+                <FormLabel>Documento</FormLabel>
+                <Input {...field} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem className="col-span-12 sm:col-span-6">
+                <FormLabel>Email</FormLabel>
+                <Input type="email" {...field} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="phone"
+            render={({ field }) => (
+              <FormItem className="col-span-12 sm:col-span-6">
+                <FormLabel>Telefone</FormLabel>
+                <Input {...field} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="col-span-12 mt-6 flex justify-center gap-4">
+          <Button type="button" variant="outline" className="w-40" onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button type="submit" className="w-40" disabled={isLoading}>
+            {isLoading && <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />}
+            Salvar
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/frontend/src/components/pages/assignor/assignor-table.tsx
+++ b/frontend/src/components/pages/assignor/assignor-table.tsx
@@ -1,0 +1,64 @@
+import { Pencil, Trash2 } from 'lucide-react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import CustomTooltip from '@/components/custom/custom-tooltip'
+import type { AssignorTableProps } from '@/types/assignor-table'
+
+export function AssignorTable({ assignors = [], onEdit, onDelete }: AssignorTableProps) {
+  return (
+    <div className="my-3 rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/40">
+            <TableHead className="w-[30%]">Id</TableHead>
+            <TableHead>Nome</TableHead>
+            <TableHead>Documento</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Telefone</TableHead>
+            <TableHead className="w-[8%] text-center">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {assignors.map((assignor) => (
+            <TableRow key={assignor.id} className="even:bg-muted/40">
+              <TableCell>{assignor.id}</TableCell>
+              <TableCell>{assignor.name}</TableCell>
+              <TableCell>{assignor.document}</TableCell>
+              <TableCell>{assignor.email}</TableCell>
+              <TableCell>{assignor.phone}</TableCell>
+              <TableCell className="flex justify-center">
+                <CustomTooltip title="Editar">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-8"
+                    onClick={() => onEdit(assignor)}
+                  >
+                    <Pencil />
+                  </Button>
+                </CustomTooltip>
+                <CustomTooltip title="Excluir">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-8"
+                    onClick={() => onDelete(assignor)}
+                  >
+                    <Trash2 className="text-destructive" />
+                  </Button>
+                </CustomTooltip>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/assignor/assignor.edit.tsx
+++ b/frontend/src/components/pages/assignor/assignor.edit.tsx
@@ -1,0 +1,49 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { Page } from '@/components/layout/page'
+import { toast } from '@/hooks/use-toast'
+import { handleApiError } from '@/helpers/api-error-handler'
+import { AssignorForm } from './assignor-form'
+import { useFetchAssignor } from '@/hooks/queries/useFetchAssignor'
+import { useUpsertAssignor, FormAssignorValues } from '@/hooks/mutations/useUpsertAssignor'
+
+export function AssignorEdit() {
+  const navigate = useNavigate()
+  const { id } = useParams()
+
+  const { data: assignor, isLoading: loadingAssignor } = useFetchAssignor(id!)
+  const upsertMutation = useUpsertAssignor(id)
+
+  const isLoading = upsertMutation.isPending
+
+  const handleSubmit = async (data: FormAssignorValues) => {
+    try {
+      await upsertMutation.mutateAsync(data)
+      toast({
+        description: id ? 'Alterações salvas com sucesso!' : 'Cadastro realizado com sucesso!',
+        variant: 'success',
+      })
+      navigate('/app/assignors')
+    } catch (error) {
+      handleApiError(error)
+    }
+  }
+
+  const handleCancel = () => {
+    navigate('/app/assignors')
+  }
+
+  if (id && loadingAssignor) {
+    return <div>Carregando...</div>
+  }
+
+  return (
+    <Page title="Cedentes">
+      <AssignorForm
+        initialData={assignor}
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+        onCancel={handleCancel}
+      />
+    </Page>
+  )
+}

--- a/frontend/src/components/pages/assignor/assignor.list.tsx
+++ b/frontend/src/components/pages/assignor/assignor.list.tsx
@@ -1,0 +1,64 @@
+import { Link, useNavigate } from 'react-router-dom'
+import { PlusIcon } from 'lucide-react'
+import { Page } from '@/components/layout/page'
+import { Button } from '@/components/ui/button'
+import { useFetchAssignors } from '@/hooks/queries/useFetchAssignors'
+import { AssignorTable } from './assignor-table'
+import { Assignor } from '@/types/assignor'
+import DeleteAlertDialog from '@/components/custom/alert-delete'
+import { useState } from 'react'
+import { useDeleteAssignor } from '@/hooks/mutations/useDeleteAssignor'
+import { handleApiError } from '@/helpers/api-error-handler'
+import { toast } from '@/hooks/use-toast'
+
+export function AssignorList() {
+  const navigate = useNavigate()
+
+  const [openAlert, setOpenAlert] = useState(false)
+  const [id, setId] = useState<string>('')
+
+  const { data: assignors, isLoading } = useFetchAssignors()
+  const deleteMutation = useDeleteAssignor()
+
+  if (isLoading) {
+    return <div>Carregando...</div>
+  }
+
+  const createNewRegister = (
+    <Button className="px-4" asChild>
+      <Link to={`/app/assignors/create`}>
+        <PlusIcon />
+        Novo registro
+      </Link>
+    </Button>
+  )
+
+  const handleEdit = (assignor: Assignor) => {
+    navigate(`/app/assignors/${assignor.id}/edit`)
+  }
+
+  const handleConfirmDelete = (assignor: Assignor) => {
+    setId(assignor.id)
+    setOpenAlert(true)
+  }
+
+  const handleDelete = async () => {
+    if (!id) return
+
+    try {
+      await deleteMutation.mutateAsync(id)
+      setId('')
+      setOpenAlert(false)
+      toast({ description: 'Registro excluído com sucesso', variant: 'success' })
+    } catch (error) {
+      handleApiError(error)
+    }
+  }
+
+  return (
+    <Page title="Cedentes" actions={createNewRegister}>
+      <AssignorTable assignors={assignors} onEdit={handleEdit} onDelete={handleConfirmDelete} />
+      <DeleteAlertDialog open={openAlert} onOpenChange={setOpenAlert} onConfirm={handleDelete} />
+    </Page>
+  )
+}

--- a/frontend/src/routes/app/assignor.tsx
+++ b/frontend/src/routes/app/assignor.tsx
@@ -1,0 +1,11 @@
+import { AssignorEdit } from '@/components/pages/assignor/assignor.edit'
+import { AssignorList } from '@/components/pages/assignor/assignor.list'
+import { RouteObject } from 'react-router-dom'
+
+const routes: RouteObject[] = [
+  { path: 'assignors', element: <AssignorList /> },
+  { path: 'assignors/create', element: <AssignorEdit /> },
+  { path: 'assignors/:id/edit', element: <AssignorEdit /> },
+]
+
+export default routes

--- a/frontend/src/types/assignor-table.ts
+++ b/frontend/src/types/assignor-table.ts
@@ -1,0 +1,7 @@
+import type { Assignor } from './assignor'
+
+export interface AssignorTableProps {
+  assignors?: Assignor[]
+  onEdit: (assignor: Assignor) => void
+  onDelete: (assignor: Assignor) => void
+}

--- a/frontend/src/types/assignor.ts
+++ b/frontend/src/types/assignor.ts
@@ -1,4 +1,7 @@
 export interface Assignor {
   id: string
   name: string
+  document: string
+  email: string
+  phone: string
 }


### PR DESCRIPTION
## Summary
- add assignor types and table interface
- implement AssignorForm, AssignorTable, list and edit pages
- create assignor routes

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run lint` in `backend` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68536173a674832f8a48e6e4a3e38fd1